### PR TITLE
Allow enabling jemalloc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ exclude = [
 
 [features]
 default = ["snappy", "lz4", "zstd", "zlib", "bzip2"]
+jemalloc = ["librocksdb-sys/jemalloc"]
 valgrind = []
 snappy = ["librocksdb-sys/snappy"]
 lz4 = ["librocksdb-sys/lz4"]

--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -13,7 +13,7 @@ links = "rocksdb"
 
 [features]
 default = [ "static" ]
-jemalloc = [ "tikv-jemalloc-sys" ]
+jemalloc = []
 static = []
 snappy = []
 lz4 = []
@@ -33,7 +33,7 @@ cc = { version = "1.0", features = ["parallel"] }
 bindgen = { version = "0.58.1", default-features = false, features = ["runtime"] }
 glob = "0.3"
 
-[dependencies.tikv-jemalloc-sys]
-version = "0.4"
+[dependencies.jemalloc-sys]
+version = "0.3"
 optional = true
 features = ["unprefixed_malloc_on_supported_platforms"]

--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -13,6 +13,7 @@ links = "rocksdb"
 
 [features]
 default = [ "static" ]
+jemalloc = [ "tikv-jemalloc-sys" ]
 static = []
 snappy = []
 lz4 = []
@@ -31,3 +32,8 @@ uuid = { version = "0.8", features = ["v4"] }
 cc = { version = "1.0", features = ["parallel"] }
 bindgen = { version = "0.58.1", default-features = false, features = ["runtime"] }
 glob = "0.3"
+
+[dependencies.tikv-jemalloc-sys]
+version = "0.4"
+optional = true
+features = ["unprefixed_malloc_on_supported_platforms"]

--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -13,7 +13,7 @@ links = "rocksdb"
 
 [features]
 default = [ "static" ]
-jemalloc = []
+jemalloc = ["jemalloc-sys"]
 static = []
 snappy = []
 lz4 = []
@@ -23,6 +23,7 @@ bzip2 = []
 
 [dependencies]
 libc = "0.2"
+jemalloc-sys = { version = "0.3", features = ["unprefixed_malloc_on_supported_platforms", "stats"], optional = true }
 
 [dev-dependencies]
 const-cstr = "0.3"
@@ -32,8 +33,3 @@ uuid = { version = "0.8", features = ["v4"] }
 cc = { version = "1.0", features = ["parallel"] }
 bindgen = { version = "0.58.1", default-features = false, features = ["runtime"] }
 glob = "0.3"
-
-[dependencies.jemalloc-sys]
-version = "0.3"
-optional = true
-features = ["unprefixed_malloc_on_supported_platforms", "stats"]

--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -36,4 +36,4 @@ glob = "0.3"
 [dependencies.jemalloc-sys]
 version = "0.3"
 optional = true
-features = ["unprefixed_malloc_on_supported_platforms"]
+features = ["unprefixed_malloc_on_supported_platforms", "stats"]

--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -23,7 +23,7 @@ bzip2 = []
 
 [dependencies]
 libc = "0.2"
-jemalloc-sys = { version = "0.3", features = ["unprefixed_malloc_on_supported_platforms", "stats"], optional = true }
+jemalloc-sys = { version = "0.3", features = ["unprefixed_malloc_on_supported_platforms"], optional = true }
 
 [dev-dependencies]
 const-cstr = "0.3"

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -177,6 +177,10 @@ fn build_rocksdb() {
 
     config.define("ROCKSDB_SUPPORT_THREAD_LOCAL", None);
 
+    if cfg!(feature = "jemalloc") {
+        config.define("WITH_JEMALLOC", "ON");
+    }
+
     if target.contains("msvc") {
         config.flag("-EHsc");
     } else {

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -179,7 +179,6 @@ fn build_rocksdb() {
 
     if cfg!(feature = "jemalloc") {
         config.define("WITH_JEMALLOC", "ON");
-        println!("cargo:rustc-link-lib=static=jemalloc");
     }
 
     if target.contains("msvc") {

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -179,6 +179,7 @@ fn build_rocksdb() {
 
     if cfg!(feature = "jemalloc") {
         config.define("WITH_JEMALLOC", "ON");
+        println!("cargo:rustc-link-lib=static=jemalloc");
     }
 
     if target.contains("msvc") {


### PR DESCRIPTION
Adds new feature `jemalloc` that links jemalloc with the binary when building RocksDB.

Enabling jemalloc shows 30% lower memory consumption after a few hours of uptime.

jemalloc also exposes memory stats that will allow us monitoring RocksDB memory usage separately.